### PR TITLE
Dockerize QANet in a GPU enabled container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# GPU enabled Docker container to run QANet
+
+FROM tensorflow/tensorflow:1.5.1-gpu
+
+RUN mkdir /home/QANet
+ADD requirements.txt /home/QANet
+RUN pip install -r /home/QANet/requirements.txt
+
+# Set the default directory where CMD will execute
+WORKDIR /home/QANet
+
+RUN apt-get update && apt-get install -y wget unzip
+
+# https://github.com/keras-team/keras/issues/9567
+RUN apt-get install -y --allow-downgrades --no-install-recommends libcudnn7=7.0.5.15-1+cuda9.0 libcudnn7-dev=7.0.5.15-1+cuda9.0 && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update

--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ python evaluate-v1.1.py ~/data/squad/dev-v1.1.json train/{model_name}/answer/ans
 
 The default directory for the tensorboard log file is `train/{model_name}/event`
 
+### Run in Docker container (optional)
+To build the Docker image (requires nvidia-docker), run
+
+```
+nvidia-docker build -t tensorflow/qanet .
+```
+
+Set volume mount paths and port mappings (for demo mode)
+
+```
+export QANETPATH={/path/to/cloned/QANet}
+export CONTAINERWORKDIR=/home/QANet
+export HOSTPORT=8080
+export CONTAINERPORT=8080
+```
+
+bash into the container
+```
+nvidia-docker run -v $QANETPATH:$CONTAINERWORKDIR -p $HOSTPORT:$CONTAINERPORT -it --rm tensorflow/qanet bash
+```
+
+Once inside the container, follow the commands provided above starting with downloading the SQuAD and Glove datasets.
+
 ### Pretrained Model
 Pretrained model weights are temporarily not available.
 

--- a/config.py
+++ b/config.py
@@ -11,11 +11,11 @@ from main import train, test, demo
 
 flags = tf.flags
 
-home = os.path.expanduser("~")
-train_file = os.path.join(home, "data", "squad", "train-v1.1.json")
-dev_file = os.path.join(home, "data", "squad", "dev-v1.1.json")
-test_file = os.path.join(home, "data", "squad", "dev-v1.1.json")
-glove_word_file = os.path.join(home, "data", "glove", "glove.840B.300d.txt")
+home = os.getcwd()
+train_file = os.path.join(home, "datasets", "squad", "train-v1.1.json")
+dev_file = os.path.join(home, "datasets", "squad", "dev-v1.1.json")
+test_file = os.path.join(home, "datasets", "squad", "dev-v1.1.json")
+glove_word_file = os.path.join(home, "datasets", "glove", "glove.840B.300d.txt")
 
 train_dir = "train"
 model_name = "FRC"

--- a/download.sh
+++ b/download.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
 # Download SQuAD
-SQUAD_DIR=~/data/squad
+PWD=$(pwd)
+SQUAD_DIR=$PWD/datasets/squad
 mkdir -p $SQUAD_DIR
 wget https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json -O $SQUAD_DIR/train-v1.1.json
 wget https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json -O $SQUAD_DIR/dev-v1.1.json
 
 # Download GloVe
-GLOVE_DIR=~/data/glove
+GLOVE_DIR=$PWD/datasets/glove
 mkdir -p $GLOVE_DIR
 wget http://nlp.stanford.edu/data/glove.840B.300d.zip -O $GLOVE_DIR/glove.840B.300d.zip
 unzip $GLOVE_DIR/glove.840B.300d.zip -d $GLOVE_DIR
@@ -22,4 +23,4 @@ unzip $GLOVE_DIR/glove.840B.300d.zip -d $GLOVE_DIR
 # unzip $FASTTEXT_DIR/wiki-news-300d-1M.vec.zip -d $FASTTEXT_DIR
 
 # Download Spacy language models
-python3 -m spacy download en
+# python3 -m spacy download en

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 tqdm
 spacy==2.0.9
+bottle


### PR DESCRIPTION
Changes made
  - Add `Dockerfile` to run QANet in a GPU enabled container
  - Add `bottle` python package to `requirements.txt`
  - Change SQuAD & Glove download destination directory in `download.sh` for easier Docker volume mapping
  - Comment out `python3 -m spacy download en` in `download.sh` (throws error since only python 2.7 spacy is installed)
  - Change source directory for SQuAD and Glove data files in `config.py` to reflect changes in `download.sh`
  - Add Docker commands to `README.md`